### PR TITLE
add more snaps

### DIFF
--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -34,6 +34,9 @@ SNAPS = {
         "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge"},
         "beta": {"ppa": "rc", "recipe": "mir-kiosk-beta"},
     },
+    "mir-kiosk-kodi": {
+        "edge": {"recipe": "mir-kiosk-kodi-edge"},
+    },
     "mir-test-tools": {
         "edge": {"ppa": "dev", "recipe": "mir-test-tools-20-edge"},
         "beta": {"ppa": "rc", "recipe": "mir-test-tools-20-beta"},

--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -30,6 +30,9 @@ TEAM = "mir-team"
 SOURCE_NAME = "mir"
 
 SNAPS = {
+    "confined-shell": {
+        "edge": {"recipe": "confined-shell-edge"},
+    },
     "mir-kiosk": {
         "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge"},
         "beta": {"ppa": "rc", "recipe": "mir-kiosk-beta"},

--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -33,6 +33,9 @@ SNAPS = {
     "confined-shell": {
         "edge": {"recipe": "confined-shell-edge"},
     },
+    "mircade": {
+        "edge": {"recipe": "mircade-edge"},
+    },
     "mir-kiosk": {
         "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge"},
         "beta": {"ppa": "rc", "recipe": "mir-kiosk-beta"},


### PR DESCRIPTION
Rather than rely on snapcraft.io builds, use LP recipes so we can trigger them on CVEs.