### PR TITLE
Show more logs and switch to pytest

### DIFF
--- a/frame/display_server.py
+++ b/frame/display_server.py
@@ -5,7 +5,7 @@ import time
 from program import Program, Command
 
 display_appear_timeout = 10
-min_frame_run_time = 0.1
+min_mir_run_time = 0.1
 
 def clear_wayland_display(runtime_dir: str, name: str) -> None:
     # Clear out any existing display before waiting for the new one
@@ -48,19 +48,19 @@ class DisplayServer:
     def __enter__(self) -> 'DisplayServer':
         runtime_dir = os.environ['XDG_RUNTIME_DIR']
         clear_wayland_display(runtime_dir, self.display_name)
-        self.frame = Program(self.command, env={'WAYLAND_DISPLAY': self.display_name})
+        self.server = Program(self.command, env={'WAYLAND_DISPLAY': self.display_name})
         try:
             wait_for_wayland_display(runtime_dir, self.display_name)
         except:
-            self.frame.kill()
+            self.server.kill()
             raise
         self.start_time = time.time()
         return self
 
     def __exit__(self, *args):
-        # If frame is run for too short a period of time it tends to not shut down correctly
-        # TODO: fix frame
-        sleep_time = self.start_time + min_frame_run_time - time.time()
+        # If Mir is run for too short a period of time it tends to not shut down correctly
+        # See https://github.com/MirServer/mir/issues/2845
+        sleep_time = self.start_time + min_mir_run_time - time.time()
         if sleep_time > 0:
             time.sleep(sleep_time)
-        self.frame.kill()
+        self.server.kill()

--- a/frame/helpers.py
+++ b/frame/helpers.py
@@ -1,17 +1,6 @@
 import os
 from typing import Iterable
 
-def combine(*arg):
-    result = [()]
-    for input_list in arg:
-        assert isinstance(input_list, list), 'combine input not all lists'
-        partial_result = result
-        result = []
-        for partial_tuple in partial_result:
-            for input_item in input_list:
-                result.append(partial_tuple + (input_item,))
-    return result
-
 complete_server_list = [
     'ubuntu-frame',
     'mir-kiosk',

--- a/frame/program.py
+++ b/frame/program.py
@@ -7,6 +7,23 @@ default_wait_timeout = 10
 
 Command = Union[str, list[str]]
 
+def format_output(name: str, output: str) -> str:
+    '''
+    After collecting a program's output into a string, this function wraps it in a border for easy
+    reading
+    '''
+    l_pad = 36 - len(name) // 2
+    r_pad = l_pad
+    if len(name) % 2 == 1:
+        r_pad -= 1
+    l_pad = max(l_pad, 1)
+    r_pad = max(r_pad, 1)
+    header = '─' * l_pad + '┤ ' + name + ' ├' + '─' * r_pad
+    divider = '\n│'
+    body = divider.join(' ' + line for line in output.strip().splitlines())
+    footer = '─' * 78
+    return '╭' + header + divider + body + '\n╰' + footer
+
 class Program:
     def __init__(self, command: Command, env: dict[str, str] = {}):
         if isinstance(command, str):
@@ -38,7 +55,7 @@ class Program:
     def wait(self, timeout=default_wait_timeout) -> None:
         raw_output, _ = self.process.communicate(timeout=timeout)
         self.output = raw_output.decode('utf-8').strip()
-        print(self.name + ' output:\n', self.output)
+        print('\n' + format_output(self.name, self.output))
         if self.process.returncode != 0:
             message = self.name
             if self.killed:

--- a/frame/program.py
+++ b/frame/program.py
@@ -28,21 +28,23 @@ class Program:
         self.killed = False
 
     def assert_running(self) -> None:
-        assert self.process.poll() is None, self.name + ' is dead'
+        if self.process.poll() is not None:
+            try:
+                self.wait()
+            except:
+                pass
+            assert False, self.name + ' is dead'
 
     def wait(self, timeout=default_wait_timeout) -> None:
         raw_output, _ = self.process.communicate(timeout=timeout)
         self.output = raw_output.decode('utf-8').strip()
+        print(self.name + ' output:\n', self.output)
         if self.process.returncode != 0:
             message = self.name
             if self.killed:
                 message += ' refused to terminate'
             else:
                 message += ' closed with exit code ' + str(self.process.returncode)
-            if self.output:
-                message += ':\n\n' + self.output
-            else:
-                message += ' and no output'
             raise RuntimeError(message)
 
     def kill(self) -> None:

--- a/frame/readme.md
+++ b/frame/readme.md
@@ -1,16 +1,16 @@
 # Ubuntu Frame Integration Tests
 
 ## To run
-`python3 -m unittest`
+`pytest`
 
 To run inside of a virtual X11 server:
-`xvfb-run python3 -m unittest`
+`xvfb-run pytest`
 
 To only run tests for a specific server, set `MIR_TEST_SERVER`:
-`MIR_TEST_SERVER=ubuntu-frame xvfb-run python3 -m unittest`
+`MIR_TEST_SERVER=ubuntu-frame xvfb-run pytest`
 
 To to run tests for some but not all servers a list can be specified:
-`MIR_TEST_SERVER=ubuntu-frame,mir-kiosk xvfb-run python3 -m unittest`
+`MIR_TEST_SERVER=ubuntu-frame,mir-kiosk xvfb-run pytest`
 
 ## To typecheck tests
 (this is also run as part of the test suite)

--- a/frame/test_apps_can_run.py
+++ b/frame/test_apps_can_run.py
@@ -1,13 +1,14 @@
 from display_server import DisplayServer
 from parameterized import parameterized
 from unittest import TestCase
-from helpers import combine, all_servers
+from helpers import all_servers
+import itertools
 import time
 
 short_wait_time = 3
 
 class TestAppsCanRun(TestCase):
-    @parameterized.expand(combine(all_servers(), [
+    @parameterized.expand(itertools.product(all_servers(), [
         'wpe-webkit-mir-kiosk.cog',
         'mir-kiosk-neverputt',
         'mir-kiosk-scummvm',

--- a/frame/test_tests.py
+++ b/frame/test_tests.py
@@ -2,8 +2,6 @@ from unittest import TestCase
 import subprocess
 import os
 
-from helpers import combine
-
 class TestTest(TestCase):
     def test_project_typechecks(self) -> None:
         project_path = os.path.dirname(__file__)
@@ -15,15 +13,3 @@ class TestTest(TestCase):
             text=True)
         if result.returncode != 0:
             raise RuntimeError('`$ mypy ' + project_path + '` failed:\n\n' + result.stdout)
-
-    def test_combine(self) -> None:
-        self.assertEqual(
-            combine([1, 2, 3], ['a', 'b']),
-            [
-                (1, 'a'),
-                (1, 'b'),
-                (2, 'a'),
-                (2, 'b'),
-                (3, 'a'),
-                (3, 'b'),
-            ])


### PR DESCRIPTION
This prints a nicely formatted log for each program run (even if the program exits successfully). Pretty formatting was borrowed from [gtk layer shell](https://github.com/wmww/gtk-layer-shell/blob/124ccc2772d5ecbb40b54872c22e594c74bd39bc/test/run-integration-test.py#L60). I also switched the recommended way of running tests to pytest, as that only shows the stdout of tests that fail. `python3 -m unittest` still works, but prints out all logs for all tests even if they pass.