### PR TITLE
Prevent gedit from consolidating multiple instances

### DIFF
--- a/frame/program.py
+++ b/frame/program.py
@@ -5,7 +5,7 @@ from typing import Union
 
 default_wait_timeout = 10
 
-Command = Union[str, list[str]]
+Command = Union[str, list[str], tuple[str, ...]]
 
 def format_output(name: str, output: str) -> str:
     '''
@@ -27,9 +27,9 @@ def format_output(name: str, output: str) -> str:
 class Program:
     def __init__(self, command: Command, env: dict[str, str] = {}):
         if isinstance(command, str):
-            self.command = [command]
+            self.command: tuple[str, ...] = (command,)
         else:
-            self.command = command
+            self.command = tuple(command)
         self.env = os.environ | env
         self.name = self.command[0]
         self.process = subprocess.Popen(

--- a/frame/test_apps_can_run.py
+++ b/frame/test_apps_can_run.py
@@ -13,7 +13,7 @@ class TestAppsCanRun(TestCase):
         'mir-kiosk-neverputt',
         'mir-kiosk-scummvm',
         'mir-kiosk-kodi',
-        'gedit',
+        ('gedit', '-s'), # -s prevents multiple instances from using the same process/window/display
         'qterminal',
     ]))
     def test_app_can_run(self, server, app) -> None:


### PR DESCRIPTION
As mentioned in the sync the integration tests fail if multiple runs hit the gedit test at the same time or gedit is already running on the system. The `-s` flag prevents gedit from combing multiple launches into a single process and fixes the problem.