### PR TITLE
Use pytest for test peramaterization

### DIFF
--- a/frame/requirements.txt
+++ b/frame/requirements.txt
@@ -1,5 +1,4 @@
 inotify
-parameterized
 mypy
 pytest
 asciinema

--- a/frame/test_apps_can_run.py
+++ b/frame/test_apps_can_run.py
@@ -1,21 +1,20 @@
 from display_server import DisplayServer
-from parameterized import parameterized
-from unittest import TestCase
 from helpers import all_servers
-import itertools
+import pytest
 import time
 
 short_wait_time = 3
 
-class TestAppsCanRun(TestCase):
-    @parameterized.expand(itertools.product(all_servers(), [
+class TestAppsCanRun:
+    @pytest.mark.parametrize('server', all_servers())
+    @pytest.mark.parametrize('app', [
         'wpe-webkit-mir-kiosk.cog',
         'mir-kiosk-neverputt',
         'mir-kiosk-scummvm',
         'mir-kiosk-kodi',
         ('gedit', '-s'), # -s prevents multiple instances from using the same process/window/display
         'qterminal',
-    ]))
+    ])
     def test_app_can_run(self, server, app) -> None:
         with DisplayServer(server) as server:
             with server.program(app) as app:

--- a/frame/test_screencopy_bandwidth.py
+++ b/frame/test_screencopy_bandwidth.py
@@ -1,16 +1,13 @@
 from display_server import DisplayServer
-from parameterized import parameterized
-from unittest import TestCase
 from helpers import all_servers
 from program import AppFixture
-import itertools
+import pytest
 import os
 import time
 
 long_wait_time = 10
 
 ASCIINEMA_CAST = f'{os.path.dirname(__file__)}/data/demo.cast'
-
 
 class QTerminal(AppFixture):
     executable = 'qterminal'
@@ -26,12 +23,12 @@ class QTerminal(AppFixture):
             'XDG_CONFIG_HOME': str(self.temppath)
         }
 
-
-class TestScreencopyBandwidth(TestCase):
-    @parameterized.expand(itertools.product(all_servers(), [
+class TestScreencopyBandwidth:
+    @pytest.mark.parametrize('server', all_servers())
+    @pytest.mark.parametrize('app', [
         (QTerminal('--execute', f'asciinema play {ASCIINEMA_CAST}'), 15),
         (AppFixture("mir-kiosk-neverputt"), None),
-    ]))
+    ])
     def test_active_app(self, server, app) -> None:
         with DisplayServer(server) as s, app[0] as a:
             with s.program(a) as p:
@@ -40,16 +37,17 @@ class TestScreencopyBandwidth(TestCase):
                 else:
                     time.sleep(long_wait_time)
 
-    @parameterized.expand(all_servers())
+    @pytest.mark.parametrize('server', all_servers())
     def test_compositor_alone(self, server) -> None:
         with DisplayServer(server) as s:
             time.sleep(long_wait_time)
 
-    @parameterized.expand(itertools.product(all_servers(), [
+    @pytest.mark.parametrize('server', all_servers())
+    @pytest.mark.parametrize('app', [
         "qterminal",
         ("gedit", "-s"),
         "mir-kiosk-kodi",
-    ]))
+    ])
     def test_inactive_app(self, server, app) -> None:
         with DisplayServer(server) as s:
             with s.program(app):

--- a/frame/test_server.py
+++ b/frame/test_server.py
@@ -1,14 +1,9 @@
-from unittest import TestCase
-
-from parameterized import parameterized
 from helpers import all_servers
-
 from display_server import DisplayServer
+import pytest
 
-class ServerSmokeTests(TestCase):
-    @parameterized.expand(
-        (s for s in all_servers())
-    )
+class ServerSmokeTests:
+    @pytest.mark.parametrize('server', all_servers())
     def test_server_can_run(self, server) -> None:
         with DisplayServer(server) as server:
             pass

--- a/frame/test_tests.py
+++ b/frame/test_tests.py
@@ -1,8 +1,7 @@
-from unittest import TestCase
 import subprocess
 import os
 
-class TestTest(TestCase):
+class TestTest:
     def test_project_typechecks(self) -> None:
         project_path = os.path.dirname(__file__)
         assert os.path.isfile(os.path.join(project_path, 'requirements.txt')), 'project path not detected correctly'


### PR DESCRIPTION
Pytest's `record_property()` feature (which will be used in a subsequent PR) isn't compatible with `parameterized`. Since pytest has it's own perfectly serviceable peramaterization, we might as well drop parameterized.

Also with pytest inheriting from `TestCase` is not necessary, and doing so breaks pytest peramaterization.