### PR TITLE
Implement roundtrip to avoid deadlocks

### DIFF
--- a/frame/screencopy_tracker.py
+++ b/frame/screencopy_tracker.py
@@ -102,7 +102,7 @@ class ScreencopyTracker(WaylandClient):
         frame.dispatcher['buffer'] = self._frame_buffer
         frame.dispatcher['damage'] = self._frame_damage
         frame.dispatcher['ready'] = self._frame_ready
-        self.display.roundtrip()
+        self.roundtrip()
         assert self.buffer is not None, 'No buffer info given'
         if is_initial:
             frame.copy(self.buffer)


### PR DESCRIPTION
I haven't seen any deadlocks with the existing code, but I have seen them with new code I'm writing and I think they're possible with existing code. My theory as to what's going on is `display.roundtrip()` dispatches, we have our own dispatch thread, and things go poorly when there are multiple dispatcher. Implementing roundtrip ourselves such that it uses our dispatcher fixes this problem.