### PR TITLE
Add virtual pointer helper and test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
       working-directory: frame
       run: |
         sudo apt-get --yes --no-install-recommends install \
+          libgtk-4-dev \
           xvfb
 
         pip install -r requirements.txt

--- a/frame/apps.py
+++ b/frame/apps.py
@@ -82,3 +82,18 @@ def gedit(*args: str, **kwargs):
 
 def wpe(*args: str, cmd: Collection[str] = (), **kwargs):
     return snap('wpe-webkit-mir-kiosk', cmd=cmd or ('wpe-webkit-mir-kiosk.cog', *args), **kwargs)
+
+def ubuntu_frame():
+    return snap('ubuntu-frame', channel='22/stable', id='ubuntu_frame')
+
+def mir_kiosk():
+    return snap('mir-kiosk', id='mir_kiosk')
+
+def confined_shell():
+    return snap('confined-shell', channel='edge', id='confined_shell')
+
+def mir_test_tools():
+    return snap('mir-test-tools', channel='22/beta', cmd=('mir-test-tools.demo-server',), id='mir_test_tools')
+
+def mir_demo_server():
+    return deb('mir_demo_server', debs=('mir-test-tools', 'mir-graphics-drivers-desktop'), id='mir_demo_server')

--- a/frame/clients/maximizing_gtk_app.py
+++ b/frame/clients/maximizing_gtk_app.py
@@ -1,0 +1,19 @@
+import gi
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gtk
+from gi.repository import GLib
+
+def on_activate(app):
+    window = Gtk.ApplicationWindow(application=app)
+    button = Gtk.Button(label="Hello, World!")
+    button.connect('clicked', lambda x: window.close())
+    window.set_child(button)
+    window.set_default_size(500, 300)
+    window.present()
+    # Doing this immediately keeps the window from being resized when it's restored
+    GLib.timeout_add(500, lambda: window.maximize())
+
+app = Gtk.Application(application_id='io.mir-server.test-gtk-app')
+app.connect('activate', on_activate)
+app.run(None)

--- a/frame/conftest.py
+++ b/frame/conftest.py
@@ -101,18 +101,20 @@ def ppa() -> None:
         subprocess.check_call(('sudo', 'add-apt-repository', '--yes', f'ppa:{RELEASE_PPA}'))
 
 @pytest.fixture(scope='function', params=(
-    apps.ubuntu_frame(),
-    apps.mir_kiosk(),
-    apps.confined_shell(),
-    apps.mir_test_tools(),
-    apps.mir_demo_server(),
+    apps.ubuntu_frame,
+    apps.mir_kiosk,
+    apps.confined_shell,
+    apps.mir_test_tools,
+    apps.mir_demo_server,
 ))
 def server(request: pytest.FixtureRequest) -> List[str]:
     '''
     Parameterizes the servers (ubuntu-frame, mir-kiosk, confined-shell, mir_demo_server),
     or installs them if `--deps` is given on the command line.
     '''
-    return request.param
+    # Have to evaluate the param ourselves, because you can't mark fixtures and so
+    # the `.deps(…)` mark never registers.
+    return _deps_install(request, request.param().marks[0].kwargs)
 
 @pytest.fixture(scope='function')
 def deps(request: pytest.FixtureRequest) -> List[str]:

--- a/frame/conftest.py
+++ b/frame/conftest.py
@@ -8,6 +8,8 @@ from typing import Any, Generator, List, Mapping, Optional, Union
 import distro
 import pytest
 
+import apps
+
 RELEASE_PPA = 'mir-team/release'
 RELEASE_PPA_ENTRY = f'https://ppa.launchpadcontent.net/{RELEASE_PPA}/ubuntu {distro.codename()}/main'
 APT_INSTALL = ('sudo', 'DEBIAN_FRONTEND=noninteractive', 'apt-get', 'install', '--yes')
@@ -99,18 +101,18 @@ def ppa() -> None:
         subprocess.check_call(('sudo', 'add-apt-repository', '--yes', f'ppa:{RELEASE_PPA}'))
 
 @pytest.fixture(scope='function', params=(
-    pytest.param({'snap': 'ubuntu-frame', 'channel': '22/stable'}, id='ubuntu_frame'),
-    pytest.param('mir-kiosk', id='mir_kiosk'),
-    pytest.param({'snap': 'confined-shell', 'channel': 'edge'}, id='confined_shell'),
-    pytest.param({'snap': 'mir-test-tools', 'channel': '22/beta', 'cmd': ('mir-test-tools.demo-server',)}, id='mir_test_tools'),
-    pytest.param({'cmd': ['mir_demo_server'], 'debs': ('mir-test-tools', 'mir-graphics-drivers-desktop')}, id='mir_demo_server'),
+    apps.ubuntu_frame(),
+    apps.mir_kiosk(),
+    apps.confined_shell(),
+    apps.mir_test_tools(),
+    apps.mir_demo_server(),
 ))
 def server(request: pytest.FixtureRequest) -> List[str]:
     '''
     Parameterizes the servers (ubuntu-frame, mir-kiosk, confined-shell, mir_demo_server),
     or installs them if `--deps` is given on the command line.
     '''
-    return _deps_install(request, request.param)
+    return request.param
 
 @pytest.fixture(scope='function')
 def deps(request: pytest.FixtureRequest) -> List[str]:

--- a/frame/conftest.py
+++ b/frame/conftest.py
@@ -58,7 +58,7 @@ def _deps_install(request: pytest.FixtureRequest, spec: Union[str, Mapping[str, 
         channel = 'latest/stable'
         pip_pkgs = ()
     else:
-        raise TypeError('Bad value for argument `spec`')
+        raise TypeError('Bad value for argument `spec`: ' + repr(spec))
 
     if request.config.getoption("--deps", False):
         missing_pkgs = []

--- a/frame/data/wlr-virtual-pointer-unstable-v1.xml
+++ b/frame/data/wlr-virtual-pointer-unstable-v1.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_virtual_pointer_unstable_v1">
+  <copyright>
+    Copyright © 2019 Josef Gajdusek
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <interface name="zwlr_virtual_pointer_v1" version="2">
+    <description summary="virtual pointer">
+      This protocol allows clients to emulate a physical pointer device. The
+      requests are mostly mirror opposites of those specified in wl_pointer.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_axis" value="0"
+        summary="client sent invalid axis enumeration value" />
+      <entry name="invalid_axis_source" value="1"
+        summary="client sent invalid axis source enumeration value" />
+    </enum>
+
+    <request name="motion">
+      <description summary="pointer relative motion event">
+        The pointer has moved by a relative amount to the previous request.
+
+        Values are in the global compositor space.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="dx" type="fixed" summary="displacement on the x-axis"/>
+      <arg name="dy" type="fixed" summary="displacement on the y-axis"/>
+    </request>
+
+    <request name="motion_absolute">
+      <description summary="pointer absolute motion event">
+        The pointer has moved in an absolute coordinate frame.
+
+        Value of x can range from 0 to x_extent, value of y can range from 0
+        to y_extent.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="x" type="uint" summary="position on the x-axis"/>
+      <arg name="y" type="uint" summary="position on the y-axis"/>
+      <arg name="x_extent" type="uint" summary="extent of the x-axis"/>
+      <arg name="y_extent" type="uint" summary="extent of the y-axis"/>
+    </request>
+
+    <request name="button">
+      <description summary="button event">
+        A button was pressed or released.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="button" type="uint" summary="button that produced the event"/>
+      <arg name="state" type="uint" enum="wl_pointer.button_state" summary="physical state of the button"/>
+    </request>
+
+    <request name="axis">
+      <description summary="axis event">
+        Scroll and other axis requests.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+    </request>
+
+    <request name="frame">
+      <description summary="end of a pointer event sequence">
+        Indicates the set of events that logically belong together.
+      </description>
+    </request>
+
+    <request name="axis_source">
+      <description summary="axis source event">
+        Source information for scroll and other axis.
+      </description>
+      <arg name="axis_source" type="uint" enum="wl_pointer.axis_source" summary="source of the axis event"/>
+    </request>
+
+    <request name="axis_stop">
+      <description summary="axis stop event">
+        Stop notification for scroll and other axes.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="the axis stopped with this event"/>
+    </request>
+
+    <request name="axis_discrete">
+      <description summary="axis click event">
+        Discrete step information for scroll and other axes.
+
+        This event allows the client to extend data normally sent using the axis
+        event with discrete value.
+      </description>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="axis" type="uint" enum="wl_pointer.axis" summary="axis type"/>
+      <arg name="value" type="fixed" summary="length of vector in touchpad coordinates"/>
+      <arg name="discrete" type="int" summary="number of steps"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer object"/>
+    </request>
+  </interface>
+
+  <interface name="zwlr_virtual_pointer_manager_v1" version="2">
+    <description summary="virtual pointer manager">
+      This object allows clients to create individual virtual pointer objects.
+    </description>
+
+    <request name="create_virtual_pointer">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The optional seat is a suggestion to the
+        compositor.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+
+    <request name="destroy" type="destructor" since="1">
+      <description summary="destroy the virtual pointer manager"/>
+    </request>
+
+    <!-- Version 2 additions -->
+    <request name="create_virtual_pointer_with_output" since="2">
+      <description summary="Create a new virtual pointer">
+        Creates a new virtual pointer. The seat and the output arguments are
+        optional. If the seat argument is set, the compositor should assign the
+        input device to the requested seat. If the output argument is set, the
+        compositor should map the input device to the requested output.
+      </description>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"/>
+      <arg name="output" type="object" interface="wl_output" allow-null="true"/>
+      <arg name="id" type="new_id" interface="zwlr_virtual_pointer_v1"/>
+    </request>
+  </interface>
+</protocol>

--- a/frame/display_server.py
+++ b/frame/display_server.py
@@ -56,7 +56,7 @@ class DisplayServer:
         clear_wayland_display(runtime_dir, self.display_name)
         self.server = await Program(self.command, env={
             'WAYLAND_DISPLAY': self.display_name,
-            'MIR_SERVER_ADD_WAYLAND_EXTENSIONS': ','.join(self.add_extensions),
+            'MIR_SERVER_ADD_WAYLAND_EXTENSIONS': ':'.join(self.add_extensions),
         }).__aenter__()
         try:
             wait_for_wayland_display(runtime_dir, self.display_name)

--- a/frame/program.py
+++ b/frame/program.py
@@ -12,7 +12,7 @@ def format_output(name: str, output: str) -> str:
     After collecting a program's output into a string, this function wraps it in a border for easy
     reading
     '''
-    l_pad = 36 - len(name) // 2
+    l_pad = 37 - len(name) // 2
     r_pad = l_pad
     if len(name) % 2 == 1:
         r_pad -= 1

--- a/frame/protocols/.gitignore
+++ b/frame/protocols/.gitignore
@@ -1,2 +1,3 @@
 wayland
 wlr_screencopy_unstable_v1
+wlr_virtual_pointer_unstable_v1

--- a/frame/protocols/__init__.py
+++ b/frame/protocols/__init__.py
@@ -15,6 +15,8 @@ def generate_protocol(name, imports: Dict[str, str]) -> Dict[str, str]:
 
 core_imports = generate_protocol('wayland', {})
 generate_protocol('wlr-screencopy-unstable-v1', core_imports)
+generate_protocol('wlr-virtual-pointer-unstable-v1', core_imports)
 
 from .wayland import *
 from .wlr_screencopy_unstable_v1 import *
+from .wlr_virtual_pointer_unstable_v1 import *

--- a/frame/requirements.txt
+++ b/frame/requirements.txt
@@ -2,3 +2,4 @@ inotify
 pytest
 pytest-asyncio
 distro
+pygobject

--- a/frame/test_screencopy_bandwidth.py
+++ b/frame/test_screencopy_bandwidth.py
@@ -64,12 +64,17 @@ class TestScreencopyBandwidth:
             await asyncio.sleep(long_wait_time)
         _record_properties(record_property, server, tracker, 2)
 
-    async def test_app_dragged_around(self, record_property, server) -> None:
+    @pytest.mark.parametrize('local_server', [
+        apps.confined_shell(),
+        apps.mir_test_tools(),
+        apps.mir_demo_server(),
+    ])
+    async def test_app_dragged_around(self, record_property, local_server) -> None:
         async def pause():
             await asyncio.sleep(0.2)
         extensions = ScreencopyTracker.required_extensions + VirtualPointer.required_extensions
         app_path = Path(__file__).parent / 'clients' / 'maximizing_gtk_app.py'
-        server = DisplayServer(server, add_extensions=extensions)
+        server = DisplayServer(local_server, add_extensions=extensions)
         app = server.program(('python3', str(app_path)))
         tracker = ScreencopyTracker(server.display_name)
         pointer = VirtualPointer(server.display_name)

--- a/frame/virtual_pointer.py
+++ b/frame/virtual_pointer.py
@@ -1,0 +1,50 @@
+from protocols import ZwlrVirtualPointerManagerV1
+from protocols.wlr_virtual_pointer_unstable_v1.zwlr_virtual_pointer_manager_v1 import ZwlrVirtualPointerManagerV1Proxy
+from protocols.wlr_virtual_pointer_unstable_v1.zwlr_virtual_pointer_v1 import ZwlrVirtualPointerV1Proxy
+from wayland_client import WaylandClient
+from typing import Optional
+from enum import IntEnum
+
+# Codes taken from input-event-codes.h
+class Button(IntEnum):
+    LEFT = 0x110
+    RIGHT = 0x111
+    MIDDLE = 0x112
+
+class VirtualPointer(WaylandClient):
+    required_extensions = ('zwlr_virtual_pointer_manager_v1',)
+
+    def __init__(self, display_name: str) -> None:
+        super().__init__(display_name)
+        self.pointer_manager: Optional[ZwlrVirtualPointerManagerV1Proxy] = None
+        self.pointer: Optional[ZwlrVirtualPointerV1Proxy] = None
+
+    def registry_global(self, registry, id_num: int, iface_name: str, version: int) -> None:
+        if iface_name == ZwlrVirtualPointerManagerV1.name:
+            self.pointer_manager = manager = registry.bind(id_num, ZwlrVirtualPointerManagerV1, version)
+            self.pointer = manager.create_virtual_pointer(None)
+
+    def connected(self) -> None:
+        pass
+
+    def disconnected(self) -> None:
+        pass
+
+    def move_to_proportional(self, x: float, y: float) -> None:
+        assert x >= 0 and x <= 1, 'x not in range 0-1'
+        assert y >= 0 and y <= 1, 'y not in range 0-1'
+        assert self.pointer is not None, 'No pointer'
+        assert self.display is not None, 'No display'
+        self.pointer.motion_absolute(self.timestamp(), int(x * 1000), int(y * 1000), 1000, 1000)
+        self.pointer.frame()
+        self.display.roundtrip()
+
+    def button(self, button: Button, state: bool) -> None:
+        assert self.pointer is not None, 'No pointer'
+        assert self.display is not None, 'No display'
+        self.pointer.button(self.timestamp(), button, 1 if state else 0)
+        self.pointer.frame()
+        self.display.roundtrip()
+
+    async def __aenter__(self) -> 'VirtualPointer':
+        return await super().__aenter__() # type: ignore

--- a/frame/virtual_pointer_debug.py
+++ b/frame/virtual_pointer_debug.py
@@ -2,13 +2,18 @@
 from virtual_pointer import VirtualPointer, Button
 import os
 import sys
+import asyncio
 import time
 
 states = {'down': True, 'up': False}
 
 def show_help() -> None:
     print(f'''
-Usage: {os.path.basename(__file__)} [COMMANDS...]
+Usage: {os.path.basename(__file__)} [ARGS, COMMANDS...]
+
+Args:
+    -h, --help      show this help text
+    --wait SECONDS  set time to wait between each command
 
 Commands:
     move X Y        move the pointer, X and Y must be floats between 0 and 1
@@ -19,31 +24,41 @@ Buttons: left, right, middle
 Button states: up, down
 ''')
 
-def run() -> None:
+async def main() -> None:
     pointer = VirtualPointer(os.environ['WAYLAND_DISPLAY'])
-    args = sys.argv[1:]
-    commands: list = []
-    while args:
-        arg = args.pop(0)
-        if arg == '--help' or arg == '-h':
-            show_help()
-            exit(0)
-        elif arg == 'move':
-            commands.append((pointer.move_to_proportional, (float(args.pop(0)), float(args.pop(0)))))
-        elif arg == 'left':
-            commands.append((pointer.button, (Button.LEFT, states[args.pop(0)])))
-        elif arg == 'right':
-            commands.append((pointer.button, (Button.RIGHT, states[args.pop(0)])))
-        elif arg == 'middle':
-            commands.append((pointer.button, (Button.MIDDLE, states[args.pop(0)])))
-        elif arg == 'sleep':
-            commands.append((time.sleep, (float(args.pop(0)),)))
-        else:
-            assert False, f'invalid argument: {arg}'
-    with pointer:
-        for command in commands:
+    wait_time = 0.0
+    try:
+        args = sys.argv[1:] or ['-h']
+        commands: list = []
+        while args:
+            arg = args.pop(0)
+            if arg == '--help' or arg == '-h':
+                show_help()
+                exit(0)
+            elif arg == '--wait':
+                wait_time = float(args.pop(0))
+            elif arg == 'move':
+                commands.append((pointer.move_to_proportional, (float(args.pop(0)), float(args.pop(0)))))
+            elif arg == 'left':
+                commands.append((pointer.button, (Button.LEFT, states[args.pop(0)])))
+            elif arg == 'right':
+                commands.append((pointer.button, (Button.RIGHT, states[args.pop(0)])))
+            elif arg == 'middle':
+                commands.append((pointer.button, (Button.MIDDLE, states[args.pop(0)])))
+            elif arg == 'sleep':
+                commands.append((time.sleep, (float(args.pop(0)),)))
+            else:
+                assert False, f'invalid argument: {arg}'
+    except Exception as e:
+        print('Argument error:', str(e))
+        show_help()
+        exit(1)
+    async with pointer:
+        for i, command in enumerate(commands):
+            if i and wait_time:
+                time.sleep(wait_time)
             print(f'{command[0].__name__}({", ".join(map(str, command[1]))})')
             command[0](*command[1])
 
 if __name__ == '__main__':
-    run()
+    asyncio.run(main())

--- a/frame/virtual_pointer_debug.py
+++ b/frame/virtual_pointer_debug.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+from virtual_pointer import VirtualPointer, Button
+import os
+import sys
+import time
+
+states = {'down': True, 'up': False}
+
+def show_help() -> None:
+    print(f'''
+Usage: {os.path.basename(__file__)} [COMMANDS...]
+
+Commands:
+    move X Y        move the pointer, X and Y must be floats between 0 and 1
+    BUTTON STATE    click or unclick a button
+    sleep SECONDS   sleep for the given number of seconds
+
+Buttons: left, right, middle
+Button states: up, down
+''')
+
+def run() -> None:
+    pointer = VirtualPointer(os.environ['WAYLAND_DISPLAY'])
+    args = sys.argv[1:]
+    commands: list = []
+    while args:
+        arg = args.pop(0)
+        if arg == '--help' or arg == '-h':
+            show_help()
+            exit(0)
+        elif arg == 'move':
+            commands.append((pointer.move_to_proportional, (float(args.pop(0)), float(args.pop(0)))))
+        elif arg == 'left':
+            commands.append((pointer.button, (Button.LEFT, states[args.pop(0)])))
+        elif arg == 'right':
+            commands.append((pointer.button, (Button.RIGHT, states[args.pop(0)])))
+        elif arg == 'middle':
+            commands.append((pointer.button, (Button.MIDDLE, states[args.pop(0)])))
+        elif arg == 'sleep':
+            commands.append((time.sleep, (float(args.pop(0)),)))
+        else:
+            assert False, f'invalid argument: {arg}'
+    with pointer:
+        for command in commands:
+            print(f'{command[0].__name__}({", ".join(map(str, command[1]))})')
+            command[0](*command[1])
+
+if __name__ == '__main__':
+    run()

--- a/frame/wayland_client.py
+++ b/frame/wayland_client.py
@@ -3,6 +3,7 @@ import pywayland.client
 from protocols.wayland.wl_registry import WlRegistryProxy
 from typing import Optional
 from abc import abstractmethod
+import time
 import asyncio
 
 class WaylandClient:
@@ -17,6 +18,9 @@ class WaylandClient:
         except Exception as e:
             asyncio.get_event_loop().remove_writer(self.display.get_fd())
             raise
+
+    def timestamp(self) -> int:
+        return int(time.monotonic() * 1000)
 
     @abstractmethod
     def registry_global(self, registry, id_num: int, iface_name: str, version: int) -> None:


### PR DESCRIPTION
Adds a class that spoofs pointer input with the virtual pointer protocol and a test that demonstrates using it. The test uses a simple GTK app written in Python, since none of the clients we already use have quite the behavior we need.

I've noticed that, weirdly, the screencopy tracker isn't detecting any frames. More investigation is needed.