### PR TITLE
Add pytest.ini to stop junit_family warning

### DIFF
--- a/frame/pytest.ini
+++ b/frame/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=xunit1


### PR DESCRIPTION
Without this we get the warning:
```
PytestWarning: record_property is incompatible with junit_family 'xunit2' (use 'legacy' or 'xunit1')
```