### PR TITLE
Fix name of smoke tests class

### DIFF
--- a/frame/test_server.py
+++ b/frame/test_server.py
@@ -2,7 +2,7 @@ from helpers import all_servers
 from display_server import DisplayServer
 import pytest
 
-class ServerSmokeTests:
+class TestServerCanRun:
     @pytest.mark.parametrize('server', all_servers())
     def test_server_can_run(self, server) -> None:
         with DisplayServer(server) as server:


### PR DESCRIPTION
Test wasn't getting run because of name