### PR TITLE
Async all the things

### DIFF
--- a/frame/display_server.py
+++ b/frame/display_server.py
@@ -1,6 +1,7 @@
 import inotify.adapters
 import os
 import time
+import asyncio
 
 from program import Program, Command
 
@@ -46,25 +47,25 @@ class DisplayServer:
             'WAYLAND_DISPLAY': self.display_name,
         } | env)
 
-    def __enter__(self) -> 'DisplayServer':
+    async def __aenter__(self) -> 'DisplayServer':
         runtime_dir = os.environ['XDG_RUNTIME_DIR']
         clear_wayland_display(runtime_dir, self.display_name)
-        self.server = Program(self.command, env={
+        self.server = await Program(self.command, env={
             'WAYLAND_DISPLAY': self.display_name,
             'MIR_SERVER_ADD_WAYLAND_EXTENSIONS': ','.join(self.add_extensions),
-        })
+        }).__aenter__()
         try:
             wait_for_wayland_display(runtime_dir, self.display_name)
         except:
-            self.server.kill()
+            await self.server.kill()
             raise
         self.start_time = time.time()
         return self
 
-    def __exit__(self, *args):
+    async def __aexit__(self, *args):
         # If Mir is run for too short a period of time it tends to not shut down correctly
         # See https://github.com/MirServer/mir/issues/2845
         sleep_time = self.start_time + min_mir_run_time - time.time()
         if sleep_time > 0:
-            time.sleep(sleep_time)
-        self.server.kill()
+            await asyncio.sleep(sleep_time)
+        await self.server.kill()

--- a/frame/test_apps_can_run.py
+++ b/frame/test_apps_can_run.py
@@ -16,7 +16,7 @@ class TestAppsCanRun:
         apps.gedit(),
         apps.qterminal(),
     ])
-    def test_app_can_run(self, server, app) -> None:
-        with DisplayServer(server) as server:
-            with server.program(app):
+    async def test_app_can_run(self, server, app) -> None:
+        async with DisplayServer(server) as server:
+            async with server.program(app):
                 time.sleep(short_wait_time)

--- a/frame/test_screencopy_bandwidth.py
+++ b/frame/test_screencopy_bandwidth.py
@@ -25,19 +25,19 @@ class TestScreencopyBandwidth:
         apps.snap('mir-kiosk-neverputt', extra=False)
     ])
     async def test_active_app(self, record_property, server, app) -> None:
-        with DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions) as s:
+        async with DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions) as s:
             tracker = ScreencopyTracker(s.display_name)
-            with tracker, s.program(app[0]) as p:
+            async with tracker, s.program(app[0]) as p:
                 if app[1]:
-                    p.wait(app[1])
+                    await asyncio.wait_for(p.wait(), timeout=app[1])
                 else:
                     await asyncio.sleep(long_wait_time)
             record_screencopy_properties(record_property, tracker, 10)
 
     async def test_compositor_alone(self, record_property, server) -> None:
-        with DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions) as s:
+        async with DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions) as s:
             tracker = ScreencopyTracker(s.display_name)
-            with tracker:
+            async with tracker:
                 await asyncio.sleep(long_wait_time)
             record_screencopy_properties(record_property, tracker, 1)
 
@@ -47,8 +47,8 @@ class TestScreencopyBandwidth:
         apps.snap('mir-kiosk-kodi'),
     ])
     async def test_inactive_app(self, record_property, server, app) -> None:
-        with DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions) as s:
+        async with DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions) as s:
             tracker = ScreencopyTracker(s.display_name)
-            with tracker, s.program(app):
+            async with tracker, s.program(app):
                 await asyncio.sleep(long_wait_time)
             record_screencopy_properties(record_property, tracker, 2)

--- a/frame/test_server.py
+++ b/frame/test_server.py
@@ -4,6 +4,6 @@ from display_server import DisplayServer
 
 class TestServerCanRun:
     @pytest.mark.smoke
-    def test_server_can_run(self, server) -> None:
-        with DisplayServer(server) as server:
+    async def test_server_can_run(self, server) -> None:
+        async with DisplayServer(server) as server:
             pass

--- a/frame/wayland_client.py
+++ b/frame/wayland_client.py
@@ -26,7 +26,7 @@ class WaylandClient:
     def disconnected(self) -> None:
         pass
 
-    def __enter__(self) -> 'WaylandClient':
+    async def __aenter__(self) -> 'WaylandClient':
         try:
             self.display.connect()
             self._registry = registry = self.display.get_registry()
@@ -36,10 +36,10 @@ class WaylandClient:
             asyncio.get_event_loop().add_writer(self.display.get_fd(), self._dispatch)
             return self
         except:
-            self.__exit__()
+            await self.__aexit__()
             raise
 
-    def __exit__(self, *args) -> None:
+    async def __aexit__(self, *args) -> None:
         asyncio.get_event_loop().remove_writer(self.display.get_fd())
         self.display.roundtrip()
         self.display.disconnect()


### PR DESCRIPTION
Turns out screencopy frames weren't being captured because we were doing non-async waiting in the tests. This makes all our context managers (including notably `Program`) async, fixing the issue. Assertions are put in place to fail tests that do not get a minimum number of frames.