### PR TITLE
tests: make pywayland optional

### DIFF
--- a/frame/requirements.txt
+++ b/frame/requirements.txt
@@ -1,5 +1,4 @@
 inotify
 pytest
 pytest-asyncio
-pywayland
 distro

--- a/frame/test_screencopy_bandwidth.py
+++ b/frame/test_screencopy_bandwidth.py
@@ -1,5 +1,4 @@
 from display_server import DisplayServer
-from screencopy_tracker import ScreencopyTracker
 import pytest
 import os
 import re
@@ -24,12 +23,14 @@ def _record_properties(fixture, server, tracker, min_frames):
     )
 
 @pytest.mark.performance
+@pytest.mark.deps('pywayland-scanner', pip_pkgs=('pywayland',))
 class TestScreencopyBandwidth:
     @pytest.mark.parametrize('app', [
         apps.qterminal('--execute', f'python3 -m asciinema play {ASCIINEMA_CAST}', pip_pkgs=('asciinema',), id='asciinema', extra=15),
         apps.snap('mir-kiosk-neverputt', extra=False)
     ])
     async def test_active_app(self, record_property, server, app) -> None:
+        from screencopy_tracker import ScreencopyTracker
         server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
         tracker = ScreencopyTracker(server.display_name)
         async with server as s, tracker, s.program(app[0]) as p:
@@ -40,6 +41,7 @@ class TestScreencopyBandwidth:
         _record_properties(record_property, server, tracker, 10)
 
     async def test_compositor_alone(self, record_property, server) -> None:
+        from screencopy_tracker import ScreencopyTracker
         server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
         tracker = ScreencopyTracker(server.display_name)
         async with server, tracker:
@@ -52,6 +54,7 @@ class TestScreencopyBandwidth:
         apps.snap('mir-kiosk-kodi'),
     ])
     async def test_inactive_app(self, record_property, server, app) -> None:
+        from screencopy_tracker import ScreencopyTracker
         server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
         tracker = ScreencopyTracker(server.display_name)
         async with server as s, tracker, s.program(app):

--- a/frame/test_tests.py
+++ b/frame/test_tests.py
@@ -8,8 +8,9 @@ from program import Program
 
 class TestTest:
     @pytest.mark.self
-    @pytest.mark.deps('python3', '-m', 'mypy', pip_pkgs=('mypy',))
+    @pytest.mark.deps('python3', '-m', 'mypy', pip_pkgs=('mypy', 'pywayland'))
     def test_project_typechecks(self, deps) -> None:
+        from protocols import WlOutput, WlShm, ZwlrScreencopyManagerV1  # noqa:F401
         project_path = os.path.dirname(__file__)
         assert os.path.isfile(os.path.join(project_path, 'requirements.txt')), 'project path not detected correctly'
         result = subprocess.run(


### PR DESCRIPTION
It fails to install on riscv64.

The import is unfortunate, and I'll think about retrieving it through the `deps` fixture in the future, but this does the job.