### PR TITLE
tests: move gobject deps to a fixture

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,9 +51,6 @@ jobs:
     - name: Set up dependencies
       working-directory: frame
       run: |
-        sudo apt-get --yes --no-install-recommends install \
-          libgtk-4-dev
-
         pip install -r requirements.txt
         python -m pytest ${{ steps.pytest-args.outputs.args }} --deps
 

--- a/frame/requirements.txt
+++ b/frame/requirements.txt
@@ -2,4 +2,3 @@ inotify
 pytest
 pytest-asyncio
 distro
-pygobject

--- a/frame/test_screencopy_bandwidth.py
+++ b/frame/test_screencopy_bandwidth.py
@@ -64,6 +64,7 @@ class TestScreencopyBandwidth:
             await asyncio.sleep(long_wait_time)
         _record_properties(record_property, server, tracker, 2)
 
+    @pytest.mark.deps(debs=('libgtk-4-dev',), pip_pkgs=(('pygobject', 'gi'),))
     @pytest.mark.parametrize('local_server', [
         apps.confined_shell(),
         apps.mir_test_tools(),


### PR DESCRIPTION
Decided to drop the executable and package checks as these will be obvious from test failures anyway.