### PR TITLE
Benchmarking for the DisplayServer and its spawned application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.pyc
 mir-ci/mir_ci/junit.xml
 .python-version
+venv

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
     patch:
       default:
         target: 0%
+
+ignore:
+  - "mir-ci/mir_ci/interfaces"

--- a/mir-ci/mir_ci/benchmarker.py
+++ b/mir-ci/mir_ci/benchmarker.py
@@ -1,0 +1,88 @@
+import asyncio
+import logging
+from typing import Dict, Callable, Optional
+from contextlib import suppress
+
+from mir_ci.interfaces.benchmarkable import Benchmarkable
+from mir_ci.interfaces.benchmarker_backend import BenchmarkBackend
+
+
+logger = logging.getLogger(__name__)
+
+
+class Benchmarker:
+    def __init__(self, programs: Dict[str, Benchmarkable], poll_time_seconds: float = 1.0):
+        self.programs = programs
+        self.backend: BenchmarkBackend = CgroupsBackend()
+        self.poll_time_seconds = poll_time_seconds
+        self.task: Optional[asyncio.Task[None]] = None
+        self.running: bool = False
+
+    async def _run(self) -> None:
+        while self.running:
+            await self.backend.poll()
+            await asyncio.sleep(self.poll_time_seconds)
+
+    async def __aenter__(self):
+        if self.running is True:
+            return self
+
+        self.running = True
+        for program_id, program in self.programs.items():
+            await program.__aenter__()
+            self.backend.add(program_id, program)
+
+        self.task = asyncio.ensure_future(self._run())
+        return self
+
+    async def __aexit__(self, *args):
+        if self.running is False:
+            return
+        
+        self.running = False
+        if self.task:
+            self.task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self.task
+
+        for program_id, program in self.programs.items():
+            await program.__aexit__()
+
+    def generate_report(self, record_property: Callable[[str, object], None]) -> None:
+        report = self.backend.generate_report()
+        for key, value in report.items():
+            record_property(key, value)
+
+
+class CgroupsBackend(BenchmarkBackend):
+    class ProcessInfo:
+        program: Benchmarkable
+        cpu_time_microseconds: int = 0
+        mem_bytes_accumulator: int = 0
+        mem_bytes_max: int = 0
+        num_data_points: int = 0
+
+        def __init__(self, program: Benchmarkable) -> None:
+            self.program = program
+        
+    def __init__(self) -> None:
+        self.data_records: Dict[str, CgroupsBackend.ProcessInfo] = {}
+
+    def add(self, name: str, program: Benchmarkable) -> None:
+        self.data_records[name] = CgroupsBackend.ProcessInfo(program)
+    
+    async def poll(self) -> None:
+        for name, info in self.data_records.items():
+            cgroup = await info.program.get_cgroup()
+            self.data_records[name].cpu_time_microseconds = cgroup.get_cpu_time_microseconds()
+            self.data_records[name].mem_bytes_accumulator += cgroup.get_current_memory()
+            self.data_records[name].mem_bytes_max = cgroup.get_peak_memory()
+            self.data_records[name].num_data_points += 1
+
+    def generate_report(self) -> Dict[str, object]:
+        result: Dict[str, object] = {}
+        for name, info in self.data_records.items():
+            result[f"{name}_cpu_time_microseconds"] = info.cpu_time_microseconds
+            result[f"{name}_max_mem_bytes"] = info.mem_bytes_max
+            result[f"{name}_avg_mem_bytes"] = 0 if info.num_data_points == 0 else info.mem_bytes_accumulator / info.num_data_points
+        return result

--- a/mir-ci/mir_ci/cgroups.py
+++ b/mir-ci/mir_ci/cgroups.py
@@ -1,0 +1,74 @@
+import os
+from typing import Iterator, TYPE_CHECKING
+import pathlib
+import asyncio
+
+if TYPE_CHECKING:
+    CreateReturnType = asyncio.Task["Cgroup"]
+else:
+    CreateReturnType = asyncio.Task
+
+class Cgroup:
+    def __init__(self, pid: int, path: pathlib.Path) -> None:
+        self.pid = pid
+        self.path = path
+
+    @staticmethod
+    def create(pid: int) -> CreateReturnType:
+        async def inner():
+            path = await Cgroup.get_cgroup_dir(pid)
+            return Cgroup(pid, path)
+        task = asyncio.create_task(inner())
+        return task
+
+    @staticmethod
+    async def get_cgroup_dir(pid: int) -> pathlib.Path:
+        MAX_ATTEMPTS = 10
+        parent_path = Cgroup._get_cgroup_dir_internal(os.getpid())
+        path = Cgroup._get_cgroup_dir_internal(pid)
+
+        for attempt in range(MAX_ATTEMPTS):
+            await asyncio.sleep(0.1)
+            path = Cgroup._get_cgroup_dir_internal(pid)
+            if path != parent_path:
+                return path
+        else:
+            raise RuntimeError(f"Unable to read cgroup directory for pid: {pid}")
+
+    @staticmethod
+    def _get_cgroup_dir_internal(pid: int) -> pathlib.Path:
+        cgroup_file = f"/proc/{pid}/cgroup"
+
+        with open(cgroup_file, "r") as group_file:
+            for line in group_file.readlines():
+                assert line.startswith("0::"), f"Line in cgroup file does not start with 0:: for pid: {pid}"
+                return pathlib.Path(f"/sys/fs/cgroup/{line[3:]}".strip())
+        raise RuntimeError(f"Unable to find path for process with pid: {pid}")
+
+    def _read_file(self, file_name: str) -> Iterator[str]:
+        file_path = f"{self.path}/{file_name}"
+        with open(file_path, "r") as file:
+            yield file.readline()
+
+    def get_cpu_time_microseconds(self) -> int:
+        try:
+            for line in self._read_file("cpu.stat"):
+                split_line = line.split(' ')
+                if split_line[0] == "usage_usec":
+                    return int(split_line[1])
+
+            raise RuntimeError("usage_usec line not found")
+        except Exception as ex:
+            raise RuntimeError(f"Unable to get the cpu time for cgroup with pid: {self.pid}") from ex
+    
+    def get_current_memory(self) -> int:
+        try:
+            return int(next(self._read_file("memory.current")))
+        except Exception as ex:
+            raise RuntimeError(f"Unable to get the current memory for cgroup with pid: {self.pid}") from ex
+    
+    def get_peak_memory(self) -> int:
+        try:
+            return int(next(self._read_file("memory.peak")))
+        except Exception as ex:
+            raise RuntimeError(f"Unable to get the peak memory for cgroup with pid: {self.pid}") from ex

--- a/mir-ci/mir_ci/clients/drag_and_drop_demo.py
+++ b/mir-ci/mir_ci/clients/drag_and_drop_demo.py
@@ -1,5 +1,8 @@
 import gi
 import sys
+import logging
+
+logger = logging.getLogger(__name__)
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf
@@ -43,7 +46,7 @@ class DragDropWindow(Gtk.Window):
     def result_callback(self, result):
         self.result = result
         if self.expect != EXCHANGE_TYPE_NONE:
-            print("expect=", self.expect, ", actual=", self.result)
+            logger.info("expect=", self.expect, ", actual=", self.result)
             exit(self.result != self.expect)
 
 class DragSourceIconView(Gtk.IconView):
@@ -197,7 +200,7 @@ if __name__ == '__main__':
             else:
                 assert False, f'invalid argument: {arg}'
     except Exception as e:
-        print('Argument error:', str(e))
+        logger.error('Argument error:', str(e))
         exit(1)
     win = DragDropWindow(source_mode=source_mode, target_mode=target_mode, expect=expect)
     win.connect("destroy", Gtk.main_quit)

--- a/mir-ci/mir_ci/interfaces/benchmarkable.py
+++ b/mir-ci/mir_ci/interfaces/benchmarkable.py
@@ -1,0 +1,15 @@
+from abc import ABC, abstractmethod
+from mir_ci.cgroups import Cgroup
+
+class Benchmarkable(ABC):
+    @abstractmethod
+    async def get_cgroup(self) -> Cgroup:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def __aenter__(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    async def __aexit__(self, *args):
+        raise NotImplementedError

--- a/mir-ci/mir_ci/interfaces/benchmarker_backend.py
+++ b/mir-ci/mir_ci/interfaces/benchmarker_backend.py
@@ -1,0 +1,22 @@
+from mir_ci.interfaces.benchmarkable import Benchmarkable
+from typing import Dict
+from abc import ABC, abstractmethod
+
+class BenchmarkBackend(ABC):
+    """
+    Abstract class that aggregates programs together and emits process stats as it is requested
+    """
+    @abstractmethod
+    def add(self, name: str, program: Benchmarkable) -> None:
+        """
+        Add a process to be benchmarked.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    async def poll(self) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def generate_report(self) -> Dict[str, object]:
+        raise NotImplementedError

--- a/mir-ci/mir_ci/pytest.ini
+++ b/mir-ci/mir_ci/pytest.ini
@@ -8,3 +8,6 @@ markers =
   xdg: mark tests
 usefixtures = deps xdg
 asyncio_mode=auto
+log_cli = True
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S

--- a/mir-ci/mir_ci/test_apps_can_run.py
+++ b/mir-ci/mir_ci/test_apps_can_run.py
@@ -1,9 +1,10 @@
 from mir_ci import SLOWDOWN
 from mir_ci.display_server import DisplayServer
 import pytest
-import time
+import asyncio
 
 from mir_ci import apps
+from mir_ci.benchmarker import Benchmarker
 
 short_wait_time = 3 * SLOWDOWN
 
@@ -17,7 +18,11 @@ class TestAppsCanRun:
         apps.pluma(),
         apps.qterminal(),
     ])
-    async def test_app_can_run(self, server, app) -> None:
-        async with DisplayServer(server) as server:
-            async with server.program(app):
-                time.sleep(short_wait_time)
+    async def test_app_can_run(self, server, app, record_property) -> None:
+        server_instance = DisplayServer(server)
+        program = server_instance.program(app)
+        benchmarker = Benchmarker({"compositor": server_instance, "client": program}, poll_time_seconds=0.1)
+        async with benchmarker:
+            await asyncio.sleep(short_wait_time)
+
+        benchmarker.generate_report(record_property)

--- a/mir-ci/mir_ci/test_drag_and_drop.py
+++ b/mir-ci/mir_ci/test_drag_and_drop.py
@@ -29,7 +29,7 @@ class TestDragAndDrop:
     async def test_source_and_dest_match(self, modern_server, app) -> None:
         modern_server = DisplayServer(modern_server, add_extensions=VirtualPointer.required_extensions)
         pointer = VirtualPointer(modern_server.display_name)
-        program = modern_server.program(app)
+        program = modern_server.program(apps.App(app))
 
         async with modern_server, program, pointer:
             await asyncio.sleep(STARTUP_TIME)
@@ -54,7 +54,7 @@ class TestDragAndDrop:
     async def test_source_and_dest_mismatch(self, modern_server, app) -> None:
         modern_server = DisplayServer(modern_server, add_extensions=VirtualPointer.required_extensions)
         pointer = VirtualPointer(modern_server.display_name)
-        program = modern_server.program(app)
+        program = modern_server.program(apps.App(app))
 
         async with modern_server, program, pointer:
             await asyncio.sleep(STARTUP_TIME)

--- a/mir-ci/mir_ci/test_screencopy_bandwidth.py
+++ b/mir-ci/mir_ci/test_screencopy_bandwidth.py
@@ -35,9 +35,9 @@ class TestScreencopyBandwidth:
     async def test_active_app(self, record_property, server, app) -> None:
         server = DisplayServer(server, add_extensions=ScreencopyTracker.required_extensions)
         tracker = ScreencopyTracker(server.display_name)
-        async with server as s, tracker, s.program(app[0]) as p:
-            if app[1]:
-                await asyncio.wait_for(p.wait(timeout=app[1]), timeout=app[1] + 1)
+        async with server as s, tracker, s.program(apps.App(app.command[0], app.app_type)) as p:
+            if app.command[1]:
+                await asyncio.wait_for(p.wait(timeout=app.command[1]), timeout=app.command[1] + 1)
             else:
                 await asyncio.sleep(long_wait_time)
         _record_properties(record_property, server, tracker, 10)
@@ -73,7 +73,7 @@ class TestScreencopyBandwidth:
         extensions = ScreencopyTracker.required_extensions + VirtualPointer.required_extensions
         app_path = Path(__file__).parent / 'clients' / 'maximizing_gtk_app.py'
         server = DisplayServer(local_server, add_extensions=extensions)
-        app = server.program(('python3', str(app_path)))
+        app = server.program(apps.App(('python3', str(app_path))))
         tracker = ScreencopyTracker(server.display_name)
         pointer = VirtualPointer(server.display_name)
         async with server, tracker, app, pointer:

--- a/mir-ci/mir_ci/test_tests.py
+++ b/mir-ci/mir_ci/test_tests.py
@@ -1,10 +1,15 @@
 import os
-import subprocess
-import time
 import pytest
 import asyncio
+import time
+import subprocess
+from unittest.mock import Mock, MagicMock, patch, mock_open
 
 from mir_ci.program import Program
+from mir_ci.benchmarker import Benchmarker
+from mir_ci.cgroups import Cgroup
+from mir_ci.apps import App, ubuntu_frame
+from mir_ci.display_server import DisplayServer
 
 class TestTest:
     @pytest.mark.self
@@ -13,8 +18,9 @@ class TestTest:
         from mir_ci.protocols import WlOutput, WlShm, ZwlrScreencopyManagerV1  # noqa:F401
         project_path = os.path.dirname(__file__)
         assert os.path.isfile(os.path.join(project_path, 'pytest.ini')), 'project path not detected correctly'
+        command = deps.command
         result = subprocess.run(
-            [*deps, project_path],
+            [*command, project_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True)
@@ -24,14 +30,14 @@ class TestTest:
 @pytest.mark.self
 class TestProgram:
     async def test_program_gives_output(self) -> None:
-        p = Program(['printf', '%s - %s', 'abc', 'xyz'])
+        p = Program(App(['printf', '%s - %s', 'abc', 'xyz']))
         async with p:
             await p.wait()
         assert p.output == 'abc - xyz'
 
     async def test_program_can_be_waited_for(self) -> None:
         start = time.time()
-        p = Program(['sh', '-c', 'sleep 1; echo abc'])
+        p = Program(App(['sh', '-c', 'sleep 1; echo abc']))
         async with p:
             await p.wait()
         elapsed = time.time() - start
@@ -40,7 +46,7 @@ class TestProgram:
 
     async def test_program_can_be_terminated(self) -> None:
         start = time.time()
-        p = Program(['sh', '-c', 'echo abc; sleep 1; echo ijk'])
+        p = Program(App(['sh', '-c', 'echo abc; sleep 1; echo ijk']))
         async with p:
             await asyncio.sleep(0.5)
             await p.kill(2)
@@ -50,10 +56,129 @@ class TestProgram:
 
     async def test_program_is_killed_when_terminate_fails(self) -> None:
         start = time.time()
-        p = Program(['sh', '-c', 'trap "" TERM; echo abc; sleep 1; echo ijk; sleep 5; echo xyz'])
+        p = Program(App(['sh', '-c', 'trap "" TERM; echo abc; sleep 1; echo ijk; sleep 5; echo xyz']))
         async with p:
             await asyncio.sleep(0.5)
             await p.kill(2)
         elapsed = time.time() - start
         assert p.output.strip() == 'abc\nijk'
         assert abs(elapsed - 2.5) < 0.1
+
+    @patch("uuid.uuid4")
+    async def test_program_runs_with_systemd_when_flag_is_set(self, mock_uuid) -> None:
+        mock_uuid.return_value = "12345"
+        start = time.time()
+        p = Program(App(['sh', '-c', 'sleep 1'], "deb"))
+        async with p:
+            await asyncio.sleep(0.5)
+            await p.kill(2)
+        mock_uuid.assert_called_once()
+
+    async def test_program_can_get_cgroup(self) -> None:
+        p = Program(App(['sh', '-c', 'sleep 100'], "deb"))
+        async with p:
+            cgroup = await p.get_cgroup()
+            assert cgroup is not None
+            await p.kill(2)
+
+
+@pytest.mark.self
+class TestBenchmarker:
+    @staticmethod
+    def create_program_mock():
+        def async_return():
+            f = asyncio.Future()
+            f.set_result(MagicMock())
+            return f
+        p = MagicMock()
+        p.get_cgroup = Mock(return_value=async_return())
+        return p
+    
+    async def test_benchmarker_with_program(self) -> None:
+        p = TestBenchmarker.create_program_mock()
+        benchmarker = Benchmarker({"program": p}, poll_time_seconds=0.1)
+        async with benchmarker:
+            await asyncio.sleep(1)
+
+        p.get_cgroup.assert_called()
+        p.__aenter__.assert_called_once()
+        p.__aexit__.assert_called_once()
+
+    async def test_benchmarker_can_generate_report(self) -> None:
+        p = TestBenchmarker.create_program_mock()
+        benchmarker = Benchmarker({"program": p}, poll_time_seconds=0.1)
+        async with benchmarker:
+            await asyncio.sleep(1)
+
+        callback = Mock()
+        benchmarker.generate_report(callback)
+        callback.assert_called()
+
+    async def test_benchmarker_cant_enter_twice(self) -> None:
+        p = TestBenchmarker.create_program_mock()
+        benchmarker = Benchmarker({"program": p}, poll_time_seconds=0.1)
+        async with benchmarker:
+            async with benchmarker:
+                await asyncio.sleep(1)
+        
+        p.__aenter__.assert_called_once()
+
+@pytest.mark.self
+class TestCgroup:
+    @patch("builtins.open", new_callable=mock_open, read_data="usage_usec 100\nline_two 30\nline_three 40\nline_four 50")
+    def test_cgroup_can_get_cpu_time_microseconds(self, mock_open):
+        cgroup = Cgroup(12345, "/fake/path")
+        assert(cgroup.get_cpu_time_microseconds() == 100)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="usage_usec string")
+    def test_cgroup_get_cpu_time_microseconds_raises_when_not_integer(self, mock_open):
+        cgroup = Cgroup(12345, "/fake/path")
+        with pytest.raises(RuntimeError, match="Unable to get the cpu time for cgroup with pid: 12345"):
+            cgroup.get_cpu_time_microseconds()
+
+    @patch("builtins.open", new_callable=mock_open, read_data="100")
+    def test_cgroup_get_cpu_time_microseconds_raises_when_usage_usec_not_found(self, mock_open):
+        cgroup = Cgroup(12345, "/fake/path")
+        with pytest.raises(RuntimeError, match="Unable to get the cpu time for cgroup with pid: 12345"):
+            cgroup.get_cpu_time_microseconds()
+
+    @patch("builtins.open", new_callable=mock_open, read_data="100")
+    def test_cgroup_can_get_current_memory(self, mock_open):
+        cgroup = Cgroup(12345, "/fake/path")
+        assert(cgroup.get_current_memory() == 100)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="string")
+    def test_cgroup_get_current_memory_raises_when_not_integer(self, mock_open):
+        cgroup = Cgroup(12345, "/fake/path")
+        with pytest.raises(RuntimeError, match="Unable to get the current memory for cgroup with pid: 12345"):
+            cgroup.get_current_memory()
+
+    @patch("builtins.open", new_callable=mock_open, read_data="100")
+    def test_cgroup_can_get_peak_memory(self, mock_open):
+        cgroup = Cgroup(12345, "/fake/path")
+        assert(cgroup.get_peak_memory() == 100)
+
+    @patch("builtins.open", new_callable=mock_open, read_data="string")
+    def test_cgroup_get_peak_memory_raises_when_not_integer(self, mock_open):
+        cgroup = Cgroup(12345, "/fake/path")
+        with pytest.raises(RuntimeError, match="Unable to get the peak memory for cgroup with pid: 12345"):
+            cgroup.get_peak_memory()
+
+    @patch("builtins.open", new_callable=mock_open, read_data="string")
+    async def test_cgroup_path_raises_assertion_error_when_contents_are_incorrect(self, mock_open):
+        with pytest.raises(AssertionError, match=f"Line in cgroup file does not start with 0:: for pid: {os.getpid()}"):
+            await Cgroup.get_cgroup_dir(12345)
+
+    @patch("builtins.open", new_callable=mock_open)
+    async def test_cgroup_path_raises_runtime_error_when_contents_are_none(self, mock_open):
+        with pytest.raises(RuntimeError, match=f"Unable to find path for process with pid: {os.getpid()}"):
+            await Cgroup.get_cgroup_dir(12345)
+
+
+@pytest.mark.self
+class TestDisplayServer:
+    async def test_can_get_cgroup(self, server):
+        server_instance = DisplayServer(server)
+        async with server_instance:
+            cgroup = await server_instance.get_cgroup()
+            assert cgroup is not None


### PR DESCRIPTION
# Benchmarking

## What's new?
- Provided a new `Benchmarker` class which works with a `cgroups` backend.
- Wrote some tests to make sure that the Benchmarker works
- Integrated the Benchmarker in `test_apps_can_run.py`

## How to test
1. `git checkout feature/benchmarks`
2. `cd mir-ci/mir-ci`
3 . `pip install -e ..`
4. `pytest --junitxml=junit.xml test_apps_can_run.py`
5. When that finishes, open up `junit.xml` and view the test results

## What do the test results look like in `junit.xml`?
Like this:
```xml
...
    <testcase classname="test_apps_can_run.TestAppsCanRun" name="test_app_can_run[mir_demo_server-qterminal]" file="test_apps_can_run.py" line="12" time="3.153">
      <properties>
        <property name="compositor_cpu_time_microseconds" value="114179"></property>
        <property name="compositor_max_mem_bytes" value="58060800"></property>
        <property name="compositor_avg_mem_bytes" value="56726775.172413796"></property>
        <property name="client_cpu_time_microseconds" value="584842"></property>
        <property name="client_max_mem_bytes" value="37314560"></property>
        <property name="client_avg_mem_bytes" value="32306846.896551725"></property>
      </properties>
    </testcase>

...
```