### PR TITLE
mir_ci: apply existing fontconfig

### DIFF
--- a/mir-ci/mir_ci/conftest.py
+++ b/mir-ci/mir_ci/conftest.py
@@ -189,9 +189,15 @@ def xdg(request: pytest.FixtureRequest, tmp_path: pathlib.Path) -> Generator:
             for var, files in mark.kwargs.items():
                 var_path = tmp_path / var
                 var_path.mkdir(exist_ok=True)
-                m.setenv(var, str(var_path))
+                # If mocking the config home, copy over any existing fontconfig
+                if var == 'XDG_CONFIG_HOME':
+                    base_config = pathlib.Path(os.environ.get(var, '~/.config')).expanduser() / 'fontconfig'
+                    if base_config.exists():
+                        shutil.copytree(str(base_config), str(var_path / 'fontconfig'), symlinks=True, ignore_dangling_symlinks=True)
+
                 for file, contents in files.items():
                     (var_path / file).parent.mkdir(exist_ok=True, parents=True)
                     with open(var_path / file, 'w') as f:
                         f.write(contents)
+                m.setenv(var, str(var_path))
         yield


### PR DESCRIPTION
Without this, qterminal couldn't find fonts on Core.