### PR TITLE
Tests for updating the display configuration while the server is running

### DIFF
--- a/mir-ci/mir_ci/output_watcher.py
+++ b/mir-ci/mir_ci/output_watcher.py
@@ -1,10 +1,11 @@
-from mir_ci.wayland_client import WaylandClient
-from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_manager_v1 import ZxdgOutputManagerV1Proxy
-from mir_ci.protocols.wayland.wl_output import WlOutputProxy
-from mir_ci.protocols import WlOutput, ZxdgOutputManagerV1
-from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_v1 import ZxdgOutputV1Proxy
-from typing import Optional, List, Callable
 import asyncio
+from typing import Callable, List, Optional
+
+from mir_ci.protocols import WlOutput, ZxdgOutputManagerV1
+from mir_ci.protocols.wayland.wl_output import WlOutputProxy
+from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_manager_v1 import ZxdgOutputManagerV1Proxy
+from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_v1 import ZxdgOutputV1Proxy
+from mir_ci.wayland_client import WaylandClient
 
 
 def passthrough(**args):
@@ -18,16 +19,11 @@ class OutputWatcher(WaylandClient):
         on_geometry: Optional[Callable[[WlOutput, int, int, int, int, int, str, str, int], None]] = None,
         on_mode: Optional[Callable[[WlOutput, int, int, int, int], None]] = None,
         on_scale: Optional[Callable[[WlOutput, int], None]] = None,
-        on_name: Optional[Callable[[WlOutput, str], None]] = None
+        on_name: Optional[Callable[[WlOutput, str], None]] = None,
     ):
         super().__init__(display_name)
         self.wl_outputs: List[WlOutputProxy] = []
-        self.callbacks = {
-            "geometry": on_geometry,
-            "mode": on_mode,
-            "scale": on_scale,
-            "name": on_name
-        }
+        self.callbacks = {"geometry": on_geometry, "mode": on_mode, "scale": on_scale, "name": on_name}
 
     def registry_global(self, registry, id_num: int, iface_name: str, version: int) -> None:
         if iface_name == WlOutput.name:
@@ -45,8 +41,10 @@ class OutputWatcher(WaylandClient):
 async def main():
     def on_scale(output: WlOutput, scale: int):
         print(scale)
+
     output_watcher = OutputWatcher("wayland-0", on_scale=on_scale)
     async with output_watcher:
         await asyncio.sleep(5)
+
 
 asyncio.run(main())

--- a/mir-ci/mir_ci/output_watcher.py
+++ b/mir-ci/mir_ci/output_watcher.py
@@ -1,0 +1,52 @@
+from mir_ci.wayland_client import WaylandClient
+from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_manager_v1 import ZxdgOutputManagerV1Proxy
+from mir_ci.protocols.wayland.wl_output import WlOutputProxy
+from mir_ci.protocols import WlOutput, ZxdgOutputManagerV1
+from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_v1 import ZxdgOutputV1Proxy
+from typing import Optional, List, Callable
+import asyncio
+
+
+def passthrough(**args):
+    pass
+
+
+class OutputWatcher(WaylandClient):
+    def __init__(
+        self,
+        display_name: str,
+        on_geometry: Optional[Callable[[WlOutput, int, int, int, int, int, str, str, int], None]] = None,
+        on_mode: Optional[Callable[[WlOutput, int, int, int, int], None]] = None,
+        on_scale: Optional[Callable[[WlOutput, int], None]] = None,
+        on_name: Optional[Callable[[WlOutput, str], None]] = None
+    ):
+        super().__init__(display_name)
+        self.wl_outputs: List[WlOutputProxy] = []
+        self.callbacks = {
+            "geometry": on_geometry,
+            "mode": on_mode,
+            "scale": on_scale,
+            "name": on_name
+        }
+
+    def registry_global(self, registry, id_num: int, iface_name: str, version: int) -> None:
+        if iface_name == WlOutput.name:
+            self.wl_outputs.append(registry.bind(id_num, WlOutput, min(WlOutput.version, version)))
+            for key in self.callbacks:
+                self.wl_outputs[-1].dispatcher[key] = self.callbacks[key]
+
+    def connected(self) -> None:
+        self.display.roundtrip()
+
+    def disconnected(self) -> None:
+        pass
+
+
+async def main():
+    def on_scale(output: WlOutput, scale: int):
+        print(scale)
+    output_watcher = OutputWatcher("wayland-0", on_scale=on_scale)
+    async with output_watcher:
+        await asyncio.sleep(5)
+
+asyncio.run(main())

--- a/mir-ci/mir_ci/output_watcher.py
+++ b/mir-ci/mir_ci/output_watcher.py
@@ -1,10 +1,8 @@
 import asyncio
 from typing import Callable, List, Optional
 
-from mir_ci.protocols import WlOutput, ZxdgOutputManagerV1
+from mir_ci.protocols import WlOutput
 from mir_ci.protocols.wayland.wl_output import WlOutputProxy
-from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_manager_v1 import ZxdgOutputManagerV1Proxy
-from mir_ci.protocols.xdg_output_unstable_v1.zxdg_output_v1 import ZxdgOutputV1Proxy
 from mir_ci.wayland_client import WaylandClient
 
 

--- a/mir-ci/mir_ci/output_watcher.py
+++ b/mir-ci/mir_ci/output_watcher.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import Callable, List, Optional
 
 from mir_ci.protocols import WlOutput
@@ -30,12 +29,3 @@ class OutputWatcher(WaylandClient):
 
     def disconnected(self) -> None:
         pass
-
-
-async def main():
-    def on_scale(output: WlOutput, scale: int):
-        print(scale)
-
-    output_watcher = OutputWatcher("wayland-0", on_scale=on_scale)
-    async with output_watcher:
-        await asyncio.sleep(5)

--- a/mir-ci/mir_ci/output_watcher.py
+++ b/mir-ci/mir_ci/output_watcher.py
@@ -6,10 +6,6 @@ from mir_ci.protocols.wayland.wl_output import WlOutputProxy
 from mir_ci.wayland_client import WaylandClient
 
 
-def passthrough(**args):
-    pass
-
-
 class OutputWatcher(WaylandClient):
     def __init__(
         self,

--- a/mir-ci/mir_ci/output_watcher.py
+++ b/mir-ci/mir_ci/output_watcher.py
@@ -45,6 +45,3 @@ async def main():
     output_watcher = OutputWatcher("wayland-0", on_scale=on_scale)
     async with output_watcher:
         await asyncio.sleep(5)
-
-
-asyncio.run(main())

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -8,40 +8,64 @@ import pytest
 from mir_ci import SLOWDOWN, apps
 from mir_ci.display_server import DisplayServer
 from mir_ci.output_watcher import OutputWatcher
+from typing import Optional, Any
 
 short_wait_time = 1 * SLOWDOWN
 
 
-class TestDisplayConfiguration:
-    @pytest.mark.parametrize(
-        "local_server",
-        [
-            # TODO: Test other servers. Frame-based servers use
-            # a configuration file that is within the snap, so it
-            # is unclear how to read/modify that file from the outside
-            apps.mir_demo_server(),
-        ],
-    )
-    @pytest.mark.deps(pip_pkgs=("pyyaml",))
-    async def test_can_update_scale(self, local_server) -> None:
+class DisplayServerStaticFile:
+    def __init__(self, local_server):
+        self.local_server = local_server
         tmp_file = tempfile.NamedTemporaryFile(delete=False)
-        tmp_filename = tmp_file.name
+        self.tmp_filename = tmp_file.name
         try:
-            os.remove(tmp_filename)
+            os.remove(self.tmp_filename)
         except OSError:
             pass
 
-        server = DisplayServer(local_server, env={"MIR_SERVER_DISPLAY_CONFIG": f"static={tmp_filename}"})
+        self.server = DisplayServer(
+            self.local_server,
+            env={"MIR_SERVER_DISPLAY_CONFIG": f"static={self.tmp_filename}"})
+
+    async def __aenter__(self) -> "DisplayServer":
+        await self.server.__aenter__()
+
+    async def __aexit__(self, *args):
+        await self.server.__aexit__(*args)
+
+    def read_config(self) -> Any:
+        yaml = importlib.import_module("yaml")
+        with open(self.tmp_filename, "r") as file:
+            # the yaml parser doesn't like tabs before our comments
+            content = file.read().replace("\t#", "  #")
+            data = yaml.safe_load(content)
+            return data
+
+    def write_config(self, content: Any) -> None:
+        yaml = importlib.import_module("yaml")
+        with open(self.tmp_filename, "w") as file:
+            yaml.dump(content, file)
+
+
+@pytest.mark.parametrize(
+    "local_server",
+    [
+        # TODO: Test other servers. Frame-based servers use
+        # a configuration file that is within the snap, so it
+        # is unclear how to read/modify that file from the outside
+        apps.mir_demo_server(),
+    ],
+)
+@pytest.mark.deps(pip_pkgs=("pyyaml",))
+class TestDisplayConfiguration:
+    async def test_can_update_scale(self, local_server) -> None:
+        server = DisplayServerStaticFile(local_server)
         on_scale = Mock()
-        watcher = OutputWatcher(server.display_name, on_scale=on_scale)
+        watcher = OutputWatcher(server.server.display_name, on_scale=on_scale)
 
         async with server, watcher:
-            yaml = importlib.import_module("yaml")
             await asyncio.sleep(short_wait_time)
-            with open(tmp_filename, "r") as file:
-                # the yaml parser doesn't like tabs before our comments
-                content = file.read().replace("\t#", "  #")
-                data = yaml.safe_load(content)
+            data = server.read_config()
 
             card = data["layouts"]["default"]["cards"][0]
             for v in card.values():
@@ -49,8 +73,28 @@ class TestDisplayConfiguration:
                     v["scale"] = 2
                     break
 
-            with open(tmp_filename, "w") as file:
-                yaml.dump(data, file)
+            server.write_config(data)
             await asyncio.sleep(short_wait_time)
 
         on_scale.assert_called_with(ANY, 2)
+
+    async def test_can_update_position(self, local_server) -> None:
+        server = DisplayServerStaticFile(local_server)
+        on_geometry = Mock()
+        watcher = OutputWatcher(server.server.display_name, on_geometry=on_geometry)
+
+        async with server, watcher:
+            await asyncio.sleep(short_wait_time)
+            data = server.read_config()
+
+            card = data["layouts"]["default"]["cards"][0]
+            for v in card.values():
+                if type(v) is dict:
+                    v["position"] = [10, 20]
+                    break
+
+            server.write_config(data)
+            await asyncio.sleep(short_wait_time)
+
+        on_geometry.assert_called_with(ANY, 10, 20, ANY, ANY, ANY, ANY, ANY, ANY)
+

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -1,8 +1,8 @@
 import asyncio
+import importlib
 import os
 
 import pytest
-import yaml
 from mir_ci import SLOWDOWN, apps
 from mir_ci.display_server import DisplayServer
 
@@ -16,6 +16,7 @@ class TestDisplayConfiguration:
             apps.mir_demo_server(),
         ],
     )
+    @pytest.mark.deps(pip_pkgs=("pyyaml",))
     async def test_can_update_scale(self, server) -> None:
         CONFIG_FILE = "/tmp/mir_ci_display_config.yaml"
         try:
@@ -25,6 +26,7 @@ class TestDisplayConfiguration:
         server = DisplayServer(server).environment("MIR_SERVER_DISPLAY_CONFIG", f"static={CONFIG_FILE}")
 
         async with server:
+            yaml = importlib.import_module("yaml")
             await asyncio.sleep(short_wait_time)
             with open(CONFIG_FILE, "r") as file:
                 # the yaml parser doesn't like tabs before our comments

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -1,0 +1,41 @@
+import pytest
+import asyncio
+import yaml
+import os
+from mir_ci import apps, SLOWDOWN
+from mir_ci.display_server import DisplayServer
+
+short_wait_time = 1 * SLOWDOWN
+
+
+class TestDisplayConfiguration:
+    @pytest.mark.parametrize(
+    "server",
+    [
+        apps.mir_demo_server(),
+    ],
+)
+    async def test_can_update_scale(self, server) -> None:
+        CONFIG_FILE = "/tmp/mir_ci_display_config.yaml"
+        try:
+            os.remove(CONFIG_FILE)
+        except OSError:
+            pass
+        server = DisplayServer(server).environment(
+            "MIR_SERVER_DISPLAY_CONFIG",
+            f"static={CONFIG_FILE}")
+
+        async with server:
+            await asyncio.sleep(short_wait_time)
+            with open(CONFIG_FILE, "r") as file:
+                # the yaml parser doesn't like tabs before our comments
+                content = file.read().replace("\t#", "  #")
+                data = yaml.safe_load(content)
+
+            data["layouts"]["default"]["cards"][0]["unknown-1"]["scale"] = "2"
+            with open(CONFIG_FILE, "w") as file:
+                yaml.dump(data, file)
+            await asyncio.sleep(short_wait_time)
+
+        assert "New display configuration:" in server.server.output
+        assert "New base display configuration:" in server.server.output

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -25,8 +25,9 @@ class DisplayServerStaticFile:
 
         self.server = DisplayServer(self.local_server, env={"MIR_SERVER_DISPLAY_CONFIG": f"static={self.tmp_filename}"})
 
-    async def __aenter__(self) -> "DisplayServer":
+    async def __aenter__(self) -> "DisplayServerStaticFile":
         await self.server.__aenter__()
+        return self
 
     async def __aexit__(self, *args):
         await self.server.__aexit__(*args)

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -11,19 +11,19 @@ short_wait_time = 1 * SLOWDOWN
 
 class TestDisplayConfiguration:
     @pytest.mark.parametrize(
-        "server",
+        "local_server",
         [
             apps.mir_demo_server(),
         ],
     )
     @pytest.mark.deps(pip_pkgs=("pyyaml",))
-    async def test_can_update_scale(self, server) -> None:
+    async def test_can_update_scale(self, local_server) -> None:
         CONFIG_FILE = "/tmp/mir_ci_display_config.yaml"
         try:
             os.remove(CONFIG_FILE)
         except OSError:
             pass
-        server = DisplayServer(server).environment("MIR_SERVER_DISPLAY_CONFIG", f"static={CONFIG_FILE}")
+        server = DisplayServer(local_server).environment("MIR_SERVER_DISPLAY_CONFIG", f"static={CONFIG_FILE}")
 
         async with server:
             yaml = importlib.import_module("yaml")

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -1,13 +1,13 @@
 import asyncio
 import importlib
 import os
+import tempfile
 from unittest.mock import ANY, Mock
 
 import pytest
 from mir_ci import SLOWDOWN, apps
 from mir_ci.display_server import DisplayServer
 from mir_ci.output_watcher import OutputWatcher
-import tempfile
 
 short_wait_time = 1 * SLOWDOWN
 

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -54,8 +54,8 @@ class DisplayServerStaticFile:
         apps.mir_demo_server(),
     ],
 )
-@pytest.mark.deps(pip_pkgs=("pyyaml",))
 class TestDisplayConfiguration:
+    @pytest.mark.deps(pip_pkgs=("pyyaml",))
     async def test_can_update_scale(self, local_server) -> None:
         server = DisplayServerStaticFile(local_server)
         on_scale = Mock()
@@ -76,6 +76,7 @@ class TestDisplayConfiguration:
 
         on_scale.assert_called_with(ANY, 2)
 
+    @pytest.mark.deps(pip_pkgs=("pyyaml",))
     async def test_can_update_position(self, local_server) -> None:
         server = DisplayServerStaticFile(local_server)
         on_geometry = Mock()

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -26,7 +26,7 @@ class TestDisplayConfiguration:
         except OSError:
             pass
 
-        server = DisplayServer(local_server).environment("MIR_SERVER_DISPLAY_CONFIG", f"static={CONFIG_FILE}")
+        server = DisplayServer(local_server, env={"MIR_SERVER_DISPLAY_CONFIG": f"static={CONFIG_FILE}"})
         on_scale = Mock()
         watcher = OutputWatcher(server.display_name, on_scale=on_scale)
 

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -38,7 +38,12 @@ class TestDisplayConfiguration:
                 content = file.read().replace("\t#", "  #")
                 data = yaml.safe_load(content)
 
-            data["layouts"]["default"]["cards"][0]["unknown-1"]["scale"] = "2"
+            card = data["layouts"]["default"]["cards"][0]
+            for k in card:
+                if type(card[k]) is dict:
+                    card[k]["scale"] = 2
+                    break
+
             with open(CONFIG_FILE, "w") as file:
                 yaml.dump(data, file)
             await asyncio.sleep(short_wait_time)

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -1,12 +1,12 @@
 import asyncio
 import importlib
 import os
+from unittest.mock import ANY, Mock
 
 import pytest
 from mir_ci import SLOWDOWN, apps
 from mir_ci.display_server import DisplayServer
 from mir_ci.output_watcher import OutputWatcher
-from unittest.mock import Mock, ANY
 
 short_wait_time = 1 * SLOWDOWN
 

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -15,6 +15,9 @@ class TestDisplayConfiguration:
     @pytest.mark.parametrize(
         "local_server",
         [
+            # TODO: Test other servers. Frame-based servers use
+            # a configuration file that is within the snap, so it
+            # is unclear how to read/modify that file from the outside
             apps.mir_demo_server(),
         ],
     )

--- a/mir-ci/mir_ci/test_display_configuration.py
+++ b/mir-ci/mir_ci/test_display_configuration.py
@@ -2,13 +2,13 @@ import asyncio
 import importlib
 import os
 import tempfile
+from typing import Any
 from unittest.mock import ANY, Mock
 
 import pytest
 from mir_ci import SLOWDOWN, apps
 from mir_ci.display_server import DisplayServer
 from mir_ci.output_watcher import OutputWatcher
-from typing import Optional, Any
 
 short_wait_time = 1 * SLOWDOWN
 
@@ -23,9 +23,7 @@ class DisplayServerStaticFile:
         except OSError:
             pass
 
-        self.server = DisplayServer(
-            self.local_server,
-            env={"MIR_SERVER_DISPLAY_CONFIG": f"static={self.tmp_filename}"})
+        self.server = DisplayServer(self.local_server, env={"MIR_SERVER_DISPLAY_CONFIG": f"static={self.tmp_filename}"})
 
     async def __aenter__(self) -> "DisplayServer":
         await self.server.__aenter__()
@@ -97,4 +95,3 @@ class TestDisplayConfiguration:
             await asyncio.sleep(short_wait_time)
 
         on_geometry.assert_called_with(ANY, 10, 20, ANY, ANY, ANY, ANY, ANY, ANY)
-

--- a/mir-ci/mir_ci/test_tests.py
+++ b/mir-ci/mir_ci/test_tests.py
@@ -13,6 +13,8 @@ from mir_ci.benchmarker import Benchmarker, CgroupsBackend
 from mir_ci.cgroups import Cgroup
 from mir_ci.display_server import DisplayServer
 from mir_ci.program import Program
+from mir_ci.output_watcher import OutputWatcher
+from mir_ci.protocols import WlOutput
 
 
 def _async_return(mock=None):
@@ -327,3 +329,18 @@ class TestDisplayServer:
             server.record_properties(mock_fixture)
 
         mock_fixture.assert_has_calls([call("server_mode", "123x456 78.9Hz"), call("server_renderer", "Mock renderer")])
+
+
+@pytest.mark.self
+class TestOutputWatcher:
+    def test_can_register(self) -> None:
+        mock_fixture = MagicMock()
+        watcher = OutputWatcher("test-display-name")
+        watcher.registry_global(mock_fixture, 12345, WlOutput.name, 1)
+        mock_fixture.assert_has_calls([
+            call.bind(12345, WlOutput, 1),
+            call.bind().dispatcher.__setitem__('geometry', None),
+            call.bind().dispatcher.__setitem__('mode', None),
+            call.bind().dispatcher.__setitem__('scale', None),
+            call.bind().dispatcher.__setitem__('name', None)
+        ])

--- a/mir-ci/pyproject.toml
+++ b/mir-ci/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pytest",
     "pytest-asyncio",
     "pywayland @ git+https://github.com/Saviq/pywayland.git@patch-1",
+    "pyyaml"
 ]
 
 [project.urls]

--- a/mir-ci/pyproject.toml
+++ b/mir-ci/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "pytest",
     "pytest-asyncio",
     "pywayland @ git+https://github.com/Saviq/pywayland.git@patch-1",
-    "pyyaml"
 ]
 
 [project.urls]


### PR DESCRIPTION
## What's new?
- Added a single test for updating the display configuration while a display server is running
- This does not work with ubuntu frame or mir-kiosk as they don't respect the environment variable
- We can add more tests if you think this is a viable route :+1: 