### PR TITLE
snaps: drop snaps we've identified to be archived

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,7 @@ jobs:
       name: Upload coverage data
       uses: codecov/codecov-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         directory: mir-ci/mir_ci
         fail_ci_if_error: true
         verbose: true

--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -85,6 +85,9 @@ SNAPS = {
     "nvidia-core22": {
         "beta": {"recipe": "nvidia-core22-beta"},
     },
+    "mir-kiosk-x11": {
+        "beta": {"ppa": "rc", "recipe": "mir-kiosk-x11-beta", "release": "focal"},
+    },
 }
 
 PENDING_BUILD = (

--- a/bin/process_snaps.py
+++ b/bin/process_snaps.py
@@ -37,9 +37,6 @@ SNAPS = {
         "20/beta": {"recipe": "graphics-test-tools-20-beta"},
         "22/beta": {"recipe": "graphics-test-tools-22-beta"},
     },
-    "mircade": {
-        "edge": {"recipe": "mircade-edge"},
-    },
     "mir-kiosk": {
         "edge": {"ppa": "dev", "recipe": "mir-kiosk-edge", "release": "focal"},
         "beta": {"ppa": "rc", "recipe": "mir-kiosk-beta", "release": "focal"},
@@ -62,10 +59,6 @@ SNAPS = {
     "miriway": {
         "edge": {"ppa": "dev", "recipe": "miriway-edge"},
         "beta": {"ppa": "rc", "recipe": "miriway-beta"},
-    },
-    "egmde": {
-        "edge": {"ppa": "dev", "recipe": "egmde-mir-edge", "release": "focal"},
-        "beta": {"ppa": "rc", "recipe": "egmde-mir-beta", "release": "focal"},
     },
     "ubuntu-frame": {
         "20/edge": {"ppa": "dev", "recipe": "ubuntu-frame-20-edge", "release": "focal"},
@@ -91,10 +84,6 @@ SNAPS = {
     },
     "nvidia-core22": {
         "beta": {"recipe": "nvidia-core22-beta"},
-    },
-    "mir-kiosk-x11": {
-        "edge": {"ppa": "dev", "recipe": "mir-kiosk-x11-edge", "release": "focal"},
-        "beta": {"ppa": "rc", "recipe": "mir-kiosk-x11-beta", "release": "focal"},
     },
 }
 


### PR DESCRIPTION
Migrating from MirServer to canonical org, we've identified these as not useful.