### PR TITLE
xdg: merge multiple xdg marks

### DIFF
--- a/mir-ci/pyproject.toml
+++ b/mir-ci/pyproject.toml
@@ -9,6 +9,7 @@ readme = "readme.md"
 requires-python = ">=3.8"
 dependencies = [
     "distro",
+    "deepmerge",
     "inotify",
     "pytest",
     "pytest-asyncio",


### PR DESCRIPTION
In newer pytest, the marks "hidden" in the parametrize mark get actioned on. This resulted in calling the `XDG_CONFIG_HOME` mark twice.

Since this is potentially valid (e.g. class-level mark, and then a function-level mark), add support for multiple marks, with the closest ones taking precedence.